### PR TITLE
Fixed PyPi pipeline, reverted to version 0.3.0 instead of 0.3.0-rc.

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -20,13 +20,13 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Publish distribution of django-guid to Test PyPI 📦
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && contains(github.event.ref, '-rc')
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && contains(github.ref, '-rc')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution of django-guid to PyPI 📦
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && !contains(github.event.ref, '-rc')
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && !contains(github.ref, '-rc')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.pypi_password }}

--- a/django_guid/__init__.py
+++ b/django_guid/__init__.py
@@ -4,4 +4,4 @@ This file is imported by setup.py
 Adding imports here will break setup.py
 """
 
-__version__ = '0.3.0-rc2'
+__version__ = '0.3.0'


### PR DESCRIPTION
The GitHub actions are not very well documented when it comes to tag events.. 

Workflow to push to PyPi in the future:
*  Bump version in `__init__.py`.   
*  Tag with `<version>-rc<number>`, for example next minor release would be `0.3.1-rc1`.
*  If you're satisfied with the result, release with a normal tag: `0.3.1`.

A `rc` tag is not needed if you have tested the PyPi release locally. 