### PR TITLE
Dashed GUID validation fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,12 +100,12 @@ Then, in your project's :code:`settings.py` add these settings:
 
 * Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
-    .. code-block:: python
+.. code-block:: python
 
-        MIDDLEWARE = [
-            'django_guid.middleware.GuidMiddleware',
-            ...
-         ]
+    MIDDLEWARE = [
+        'django_guid.middleware.GuidMiddleware',
+        ...
+     ]
 
 
 * Add a filter to your ``LOGGING``:

--- a/README.rst
+++ b/README.rst
@@ -98,17 +98,17 @@ Install using pip:
 
 Then, in your project's :code:`settings.py` add these settings:
 
-``-`` Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
+* Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
-.. code-block:: python
+    .. code-block:: python
 
-    MIDDLEWARE = [
-        'django_guid.middleware.GuidMiddleware',
-        ...
-     ]
+        MIDDLEWARE = [
+            'django_guid.middleware.GuidMiddleware',
+            ...
+         ]
 
 
-``-`` Add a filter to your ``LOGGING``:
+* Add a filter to your ``LOGGING``:
 
 .. code-block:: python
 
@@ -122,7 +122,7 @@ Then, in your project's :code:`settings.py` add these settings:
     }
 
 
-``-`` Put that filter in your handler:
+* Put that filter in your handler:
 
 .. code-block:: python
 
@@ -137,7 +137,7 @@ Then, in your project's :code:`settings.py` add these settings:
         }
     }
 
-``-`` Lastly make sure we add the new `correlation_id` filter to the formatters:
+* Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Install using pip:
 
 Then, in your project's :code:`settings.py` add these settings:
 
-- Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
+``-`` Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
 .. code-block:: python
 
@@ -108,11 +108,12 @@ Then, in your project's :code:`settings.py` add these settings:
      ]
 
 
-- Add a filter to your ``LOGGING``:
+``-`` Add a filter to your ``LOGGING``:
 
 .. code-block:: python
 
     LOGGING = {
+        ...
         'filters': {
             'correlation_id': {
                 '()': 'django_guid.log_filters.CorrelationId'
@@ -121,11 +122,12 @@ Then, in your project's :code:`settings.py` add these settings:
     }
 
 
-- Put that filter in your handler:
+``-`` Put that filter in your handler:
 
 .. code-block:: python
 
     LOGGING = {
+        ...
         'handlers': {
             'console': {
                 'class': 'logging.StreamHandler',
@@ -135,11 +137,12 @@ Then, in your project's :code:`settings.py` add these settings:
         }
     }
 
-- Lastly make sure we add the new `correlation_id` filter to the formatters:
+``-`` Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 
     LOGGING = {
+        ...
         'formatters': {
             'medium': {
                 'format': '%(levelname)s %(asctime)s [%(correlation_id)s] %(name)s %(message)s'
@@ -152,18 +155,20 @@ If these settings were confusing, please have a look in the demo project's
 
 
 
-These are all the configurations you need to generate correlation-ID's for all you logging. If you also wish to add logging from the package middleware itself, you can also add :code:`django_guid` as a logger in your project:
+If you wish to aggregate the django-guid logs to your console or other handlers, add django_guid to your loggers in the project. Example:
 
 .. code-block:: python
-
-    'loggers': {
+    LOGGING = {
         ...
-        'django_guid': {
-            'handlers': ['console', 'logstash'],
-            'level': 'WARNING',
-            'propagate': False,
+        'loggers': {
+            'django_guid': {
+                'handlers': ['console', 'logstash'],
+                'level': 'WARNING',
+                'propagate': False,
+            }
         }
     }
+
 
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -91,17 +91,14 @@ Settings
 Installation
 ------------
 
-Python package::
+Install using pip:
 
     pip install django-guid
 
-In your project's :code:`settings.py` add these settings:
 
-(If these settings are confusing, please have a look in the demo project
-`settings.py <https://github.com/JonasKs/django-guid/blob/master/demoproj/settings.py>`_ file for a complete setup.)
+Then, in your project's :code:`settings.py` add these settings:
 
-
-Add the middleware to the :code:`MIDDLEWARE` setting (To ensure the GUID to be injected in all logs, put it on top):
+- Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
 .. code-block:: python
 
@@ -111,7 +108,7 @@ Add the middleware to the :code:`MIDDLEWARE` setting (To ensure the GUID to be i
      ]
 
 
-Add a filter to your ``LOGGING``:
+- Add a filter to your ``LOGGING``:
 
 .. code-block:: python
 
@@ -124,7 +121,7 @@ Add a filter to your ``LOGGING``:
     }
 
 
-and put that filter in your handler:
+- Put that filter in your handler:
 
 .. code-block:: python
 
@@ -138,7 +135,7 @@ and put that filter in your handler:
         }
     }
 
-and lastly make sure we add the new `correlation_id` filter to the formatters:
+- Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 
@@ -150,6 +147,25 @@ and lastly make sure we add the new `correlation_id` filter to the formatters:
         }
     }
 
+If these settings were confusing, please have a look in the demo project's
+`settings.py <https://github.com/JonasKs/django-guid/blob/master/demoproj/settings.py>`_ file for a complete example.
+
+
+
+These are all the configurations you need to generate correlation-ID's for all you logging. If you also wish to add logging from the package middleware itself, you can also add :code:`django_guid` as a logger in your project:
+
+.. code-block:: python
+
+    'loggers': {
+        ...
+        'django_guid': {
+            'handlers': ['console', 'logstash'],
+            'level': 'WARNING',
+            'propagate': False,
+        }
+    }
+
+----------
 
 Inspired by `django-log-request-id <https://github.com/dabapps/django-log-request-id>`_ with a complete rewritten
 `django-echelon <https://github.com/seveas/django-echelon>`_ approach. 

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Install using pip:
 
 Then, in your project's :code:`settings.py` add these settings:
 
-* Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
+1. Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
 .. code-block:: python
 
@@ -108,7 +108,7 @@ Then, in your project's :code:`settings.py` add these settings:
      ]
 
 
-* Add a filter to your ``LOGGING``:
+2. Add a filter to your ``LOGGING``:
 
 .. code-block:: python
 
@@ -122,7 +122,7 @@ Then, in your project's :code:`settings.py` add these settings:
     }
 
 
-* Put that filter in your handler:
+3. Put that filter in your handler:
 
 .. code-block:: python
 
@@ -137,7 +137,7 @@ Then, in your project's :code:`settings.py` add these settings:
         }
     }
 
-* Lastly make sure we add the new `correlation_id` filter to the formatters:
+4. Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -158,6 +158,7 @@ If these settings were confusing, please have a look in the demo project's
 If you wish to aggregate the django-guid logs to your console or other handlers, add django_guid to your loggers in the project. Example:
 
 .. code-block:: python
+
     LOGGING = {
         ...
         'loggers': {

--- a/django_guid/__init__.py
+++ b/django_guid/__init__.py
@@ -4,4 +4,4 @@ This file is imported by setup.py
 Adding imports here will break setup.py
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/django_guid/middleware.py
+++ b/django_guid/middleware.py
@@ -98,7 +98,7 @@ class GuidMiddleware(object):
         :return: bool
         """
         try:
-            return original_guid.replace('-','') == uuid.UUID(original_guid, version=4).hex
+            return bool(uuid.UUID(original_guid, version=4).hex)
         except ValueError:
             logger.warning('Failed to validate GUID %s', original_guid)
             return False

--- a/django_guid/middleware.py
+++ b/django_guid/middleware.py
@@ -98,7 +98,7 @@ class GuidMiddleware(object):
         :return: bool
         """
         try:
-            return original_guid == uuid.UUID(original_guid, version=4).hex
+            return original_guid.replace('-','') == uuid.UUID(original_guid, version=4).hex
         except ValueError:
             return False
 

--- a/django_guid/middleware.py
+++ b/django_guid/middleware.py
@@ -7,7 +7,7 @@ from django.http import HttpRequest, HttpResponse
 
 from django_guid.config import settings
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('django_guid')
 
 
 class GuidMiddleware(object):

--- a/django_guid/middleware.py
+++ b/django_guid/middleware.py
@@ -100,6 +100,7 @@ class GuidMiddleware(object):
         try:
             return original_guid.replace('-','') == uuid.UUID(original_guid, version=4).hex
         except ValueError:
+            logger.warning('Failed to validate GUID %s', original_guid)
             return False
 
     def _get_correlation_id_from_header(self, request: HttpRequest) -> str:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,7 +17,8 @@ Install using pip:
 
 Then, in your project's :code:`settings.py` add these settings:
 
-``-`` Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
+::
+    Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
 .. code-block:: python
 
@@ -27,7 +28,8 @@ Then, in your project's :code:`settings.py` add these settings:
      ]
 
 
-``-`` Add a filter to your ``LOGGING``:
+::
+    Add a filter to your ``LOGGING``:
 
 .. code-block:: python
 
@@ -57,7 +59,8 @@ Then, in your project's :code:`settings.py` add these settings:
         }
     }
 
-+ Lastly make sure we add the new `correlation_id` filter to the formatters:
+::
+    Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,12 +19,12 @@ Then, in your project's :code:`settings.py` add these settings:
 
 * Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
-    .. code-block:: python
+.. code-block:: python
 
-        MIDDLEWARE = [
-            'django_guid.middleware.GuidMiddleware',
-            ...
-         ]
+    MIDDLEWARE = [
+        'django_guid.middleware.GuidMiddleware',
+        ...
+     ]
 
 
 * Add a filter to your ``LOGGING``:
@@ -87,4 +87,3 @@ If you wish to aggregate the django-guid logs to your console or other handlers,
             }
         }
     }
-

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,7 +17,7 @@ Install using pip:
 
 Then, in your project's :code:`settings.py` add these settings:
 
-* Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
+1. Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
 .. code-block:: python
 
@@ -27,7 +27,7 @@ Then, in your project's :code:`settings.py` add these settings:
      ]
 
 
-* Add a filter to your ``LOGGING``:
+2. Add a filter to your ``LOGGING``:
 
 .. code-block:: python
 
@@ -41,7 +41,7 @@ Then, in your project's :code:`settings.py` add these settings:
     }
 
 
-* Put that filter in your handler:
+3. Put that filter in your handler:
 
 .. code-block:: python
 
@@ -56,7 +56,7 @@ Then, in your project's :code:`settings.py` add these settings:
         }
     }
 
-* Lastly make sure we add the new `correlation_id` filter to the formatters:
+4. Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -77,6 +77,7 @@ If these settings were confusing, please have a look in the demo project's
 If you wish to aggregate the django-guid logs to your console or other handlers, add django_guid to your loggers in the project. Example:
 
 .. code-block:: python
+
     LOGGING = {
         ...
         'loggers': {

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -10,18 +10,14 @@ Requirements
 Package installation
 --------------------
 
-Python package::
+Install using pip:
 
-    pip install django-auth-adfs
-
-
-In your project's :code:`settings.py` add these settings:
-
-(If these settings are confusing, please have a look in the demo project
-`settings.py <https://github.com/JonasKs/django-guid/blob/master/demoproj/settings.py>`_ file for a complete setup.)
+    pip install django-guid
 
 
-Add the middleware to the :code:`MIDDLEWARE` setting (To ensure the GUID to be injected in all logs, put it on top):
+Then, in your project's :code:`settings.py` add these settings:
+
+``-`` Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
 .. code-block:: python
 
@@ -31,11 +27,12 @@ Add the middleware to the :code:`MIDDLEWARE` setting (To ensure the GUID to be i
      ]
 
 
-Add a filter to your ``LOGGING``:
+``-`` Add a filter to your ``LOGGING``:
 
 .. code-block:: python
 
     LOGGING = {
+        ...
         'filters': {
             'correlation_id': {
                 '()': 'django_guid.log_filters.CorrelationId'
@@ -44,11 +41,12 @@ Add a filter to your ``LOGGING``:
     }
 
 
-and put that filter in your handler:
+``-`` Put that filter in your handler:
 
 .. code-block:: python
 
     LOGGING = {
+        ...
         'handlers': {
             'console': {
                 'class': 'logging.StreamHandler',
@@ -58,14 +56,35 @@ and put that filter in your handler:
         }
     }
 
-and lastly make sure we add the new `correlation_id` filter to the formatters:
+``-`` Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 
     LOGGING = {
+        ...
         'formatters': {
             'medium': {
                 'format': '%(levelname)s %(asctime)s [%(correlation_id)s] %(name)s %(message)s'
             }
         }
     }
+
+If these settings were confusing, please have a look in the demo project's
+`settings.py <https://github.com/JonasKs/django-guid/blob/master/demoproj/settings.py>`_ file for a complete example.
+
+
+
+If you wish to aggregate the django-guid logs to your console or other handlers, add django_guid to your loggers in the project. Example:
+
+.. code-block:: python
+    LOGGING = {
+        ...
+        'loggers': {
+            'django_guid': {
+                'handlers': ['console', 'logstash'],
+                'level': 'WARNING',
+                'propagate': False,
+            }
+        }
+    }
+

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,7 +41,8 @@ Then, in your project's :code:`settings.py` add these settings:
     }
 
 
-``-`` Put that filter in your handler:
+::
+    Put that filter in your handler:
 
 .. code-block:: python
 
@@ -56,7 +57,7 @@ Then, in your project's :code:`settings.py` add these settings:
         }
     }
 
-``-`` Lastly make sure we add the new `correlation_id` filter to the formatters:
++ Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,19 +17,17 @@ Install using pip:
 
 Then, in your project's :code:`settings.py` add these settings:
 
-::
-    Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
+* Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
 
-.. code-block:: python
+    .. code-block:: python
 
-    MIDDLEWARE = [
-        'django_guid.middleware.GuidMiddleware',
-        ...
-     ]
+        MIDDLEWARE = [
+            'django_guid.middleware.GuidMiddleware',
+            ...
+         ]
 
 
-::
-    Add a filter to your ``LOGGING``:
+* Add a filter to your ``LOGGING``:
 
 .. code-block:: python
 
@@ -43,8 +41,7 @@ Then, in your project's :code:`settings.py` add these settings:
     }
 
 
-::
-    Put that filter in your handler:
+* Put that filter in your handler:
 
 .. code-block:: python
 
@@ -59,8 +56,7 @@ Then, in your project's :code:`settings.py` add these settings:
         }
     }
 
-::
-    Lastly make sure we add the new `correlation_id` filter to the formatters:
+* Lastly make sure we add the new `correlation_id` filter to the formatters:
 
 .. code-block:: python
 

--- a/tests/functional/test_middleware.py
+++ b/tests/functional/test_middleware.py
@@ -57,6 +57,7 @@ def test_request_with_invalid_correlation_id(client, caplog, mock_uuid):
     response = client.get('/', **{'HTTP_Correlation-ID': 'bad-guid'})
     expected = [
         ('Correlation-ID found in the header: bad-guid', None),
+        ('Failed to validate GUID bad-guid', None),
         ('bad-guid is not a valid GUID. New GUID is 704ae5472cae4f8daa8f2cc5a5a8mock', None),
         ('This log message should have a GUID', '704ae5472cae4f8daa8f2cc5a5a8mock'),
         ('Some warning in a function', '704ae5472cae4f8daa8f2cc5a5a8mock'),
@@ -64,6 +65,7 @@ def test_request_with_invalid_correlation_id(client, caplog, mock_uuid):
     ]
     assert [(x.message, x.correlation_id) for x in caplog.records] == expected
     assert response['Correlation-ID'] == '704ae5472cae4f8daa8f2cc5a5a8mock'
+    print(caplog.records)
 
 
 def test_request_with_invalid_correlation_id_without_validation(client, caplog, monkeypatch):

--- a/tests/functional/test_middleware.py
+++ b/tests/functional/test_middleware.py
@@ -65,7 +65,6 @@ def test_request_with_invalid_correlation_id(client, caplog, mock_uuid):
     ]
     assert [(x.message, x.correlation_id) for x in caplog.records] == expected
     assert response['Correlation-ID'] == '704ae5472cae4f8daa8f2cc5a5a8mock'
-    print(caplog.records)
 
 
 def test_request_with_invalid_correlation_id_without_validation(client, caplog, monkeypatch):

--- a/tests/unit/test_guid_validation.py
+++ b/tests/unit/test_guid_validation.py
@@ -2,8 +2,8 @@ from django_guid.middleware import GuidMiddleware
 
 
 def test_valid_guid():
-    assert (GuidMiddleware._validate_guid("07742cab407e4e8089ebfd191acbb752") is True)
+    assert (GuidMiddleware._validate_guid('07742cab407e4e8089ebfd191acbb752') is True)
 
 
 def test_is_valid_dashed_guid():
-    assert (GuidMiddleware._validate_guid("07742cab-407e-4e80-89eb-fd191acbb752") is True)
+    assert (GuidMiddleware._validate_guid('07742cab-407e-4e80-89eb-fd191acbb752') is True)

--- a/tests/unit/test_guid_validation.py
+++ b/tests/unit/test_guid_validation.py
@@ -1,0 +1,9 @@
+from django_guid.middleware import GuidMiddleware
+
+
+def test_valid_guid():
+    assert (GuidMiddleware._validate_guid("07742cab407e4e8089ebfd191acbb752") is True)
+
+
+def test_is_valid_dashed_guid():
+    assert (GuidMiddleware._validate_guid("07742cab-407e-4e80-89eb-fd191acbb752") is True)


### PR DESCRIPTION
Dashed GUIDs sent in via headers (e.g., "07742cab-407e-4e80-89eb-fd191acbb752"), were not validated correctly. In this PR, I've:

- Added a test to cover validation with and without dashes
- Changed the middleware.py logger name to `django_guid`
- Added a WARNING-logger for when validation fails. I think this is a pretty serious error that you want to be alerted about when you're setting up django_guid.
- Added a section to the README about including `django_guid` as a logger in your project.
- Made some minor edits to the README - feel free to discard these haha
- Bumped version to 1.0.1