### PR TITLE
Expose Header Option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,21 @@
 Changelog
 =========
 
+`1.1.0`_ - 2020-02-10
+---------------------
+
+**Features**
+
+* Added a ``EXPOSE_HEADER`` setting, which will add the ``Access-Control-Expose-Headers`` with the ``RETURN_HEADER`` as value to the response. This is to allow the JavaScript Fetch API to access the header with the GUID
+
+
+
 `1.0.1`_ - 2020-02-08
 ---------------------
+
+**Bugfix**
+
+* Fixed validation of incoming GUID
 
 **Improvements**
 
@@ -120,3 +133,4 @@ Changelog
 .. _0.3.1: https://github.com/jonasks/django-guid/compare/0.3.0...0.3.1
 .. _1.0.0: https://github.com/jonasks/django-guid/compare/0.3.0...1.0.0
 .. _1.0.1: https://github.com/jonasks/django-guid/compare/1.0.0...1.0.1
+.. _1.1.0: https://github.com/jonasks/django-guid/compare/1.0.1...1.1.0

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,13 @@ Settings
 
     Default: True
 
+* :code:`RETURN_HEADER`
+        Whether to return :code:`Access-Control-Expose-Headers` for the GUID header if
+        :code:`RETURN_HEADER` is :code:`True`, has no effect if :code:`RETURN_HEADER` is :code:`False`.
+        This is allows the JavaScript Fetch API to access the header when CORS is enabled.
+
+    Default: True
+
 
 Installation
 ------------
@@ -152,4 +159,4 @@ and lastly make sure we add the new `correlation_id` filter to the formatters:
 
 
 Inspired by `django-log-request-id <https://github.com/dabapps/django-log-request-id>`_ with a complete rewritten
-`django-echelon <https://github.com/seveas/django-echelon>`_ approach. 
+`django-echelon <https://github.com/seveas/django-echelon>`_ approach.

--- a/django_guid/__init__.py
+++ b/django_guid/__init__.py
@@ -4,4 +4,4 @@ This file is imported by setup.py
 Adding imports here will break setup.py
 """
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/django_guid/config.py
+++ b/django_guid/config.py
@@ -34,7 +34,7 @@ class Settings(object):
                 raise ImproperlyConfigured('GUID_HEADER_NAME must be a string')  # Note: Case insensitive
             if not isinstance(self.RETURN_HEADER, bool):
                 raise ImproperlyConfigured('RETURN_HEADER must be a boolean')
-            if not isinstance(self.RETURN_HEADER, bool):
+            if not isinstance(self.EXPOSE_HEADER, bool):
                 raise ImproperlyConfigured('EXPOSE_HEADER must be a boolean')
         else:
             pass  # Do nothing if DJANGO_GUID not found in settings

--- a/django_guid/config.py
+++ b/django_guid/config.py
@@ -14,6 +14,7 @@ class Settings(object):
         self.VALIDATE_GUID = True
         self.SKIP_CLEANUP = False
         self.RETURN_HEADER = True
+        self.EXPOSE_HEADER = True
 
         if hasattr(django_settings, 'DJANGO_GUID'):
             _settings = django_settings.DJANGO_GUID
@@ -33,6 +34,8 @@ class Settings(object):
                 raise ImproperlyConfigured('GUID_HEADER_NAME must be a string')  # Note: Case insensitive
             if not isinstance(self.RETURN_HEADER, bool):
                 raise ImproperlyConfigured('RETURN_HEADER must be a boolean')
+            if not isinstance(self.RETURN_HEADER, bool):
+                raise ImproperlyConfigured('EXPOSE_HEADER must be a boolean')
         else:
             pass  # Do nothing if DJANGO_GUID not found in settings
 

--- a/django_guid/middleware.py
+++ b/django_guid/middleware.py
@@ -42,6 +42,8 @@ class GuidMiddleware(object):
         response = self.get_response(request)
         if settings.RETURN_HEADER:
             response[settings.GUID_HEADER_NAME] = self.get_guid()  # Adds the GUID to the response header
+            if settings.EXPOSE_HEADER:
+                response['Access-Control-Expose-Headers'] = settings.GUID_HEADER_NAME
         if not settings.SKIP_CLEANUP:
             # Delete the current request to avoid memory leak
             self.delete_guid()

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -51,5 +51,6 @@ EXPOSE_HEADER
 * **Default**: ``True``
 * **Type**: ``boolean``
 
-Whether to return ``Access-Control-Expose-Headers`` for the GUID header if ``RETURN_HEADER`` is ``True``.
+Whether to return :code:`Access-Control-Expose-Headers` for the GUID header if
+:code:`RETURN_HEADER` is :code:`True`, has no effect if :code:`RETURN_HEADER` is :code:`False`.
 This is allows the JavaScript Fetch API to access the header when CORS is enabled.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -44,3 +44,12 @@ RETURN_HEADER
 
 Whether to return the GUID (Correlation-ID) as a header in the response or not.
 It will have the same name as the :code:`GUID_HEADER_NAME` setting.
+
+
+EXPOSE_HEADER
+-------------
+* **Default**: ``True``
+* **Type**: ``boolean``
+
+Whether to return ``Access-Control-Expose-Headers`` for the GUID header if ``RETURN_HEADER`` is ``True``.
+This is allows the JavaScript Fetch API to access the header when CORS is enabled.

--- a/tests/functional/test_middleware.py
+++ b/tests/functional/test_middleware.py
@@ -106,6 +106,28 @@ def test_no_return_header_and_drf_url(client, caplog, monkeypatch, mock_uuid):
     assert not response.get('Correlation-ID')
 
 
+def test_no_expose_header(client, monkeypatch, mock_uuid):
+    """
+    Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to False
+    """
+    from django_guid.config import settings as guid_settings
+
+    monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', False)
+    response = client.get('/api')
+    assert not response.get('Access-Control-Expose-Headers')
+
+
+def test_expose_header(client, monkeypatch, mock_uuid):
+    """
+    Tests that it does return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to True
+    """
+    from django_guid.config import settings as guid_settings
+
+    monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', True)
+    response = client.get('/api')
+    assert response.get('Access-Control-Expose-Headers')
+
+
 #
 # Important: All tests below this comment should have SKIP_CLEANUP set to True.
 #

--- a/tests/functional/test_middleware.py
+++ b/tests/functional/test_middleware.py
@@ -106,9 +106,10 @@ def test_no_return_header_and_drf_url(client, caplog, monkeypatch, mock_uuid):
     assert not response.get('Correlation-ID')
 
 
-def test_no_expose_header(client, monkeypatch, mock_uuid):
+def test_no_expose_header_return_header_true(client, monkeypatch, mock_uuid):
     """
     Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to False
+    and RETURN_HEADER is True
     """
     from django_guid.config import settings as guid_settings
 
@@ -117,15 +118,57 @@ def test_no_expose_header(client, monkeypatch, mock_uuid):
     assert not response.get('Access-Control-Expose-Headers')
 
 
-def test_expose_header(client, monkeypatch, mock_uuid):
+def test_expose_header_return_header_true(client, monkeypatch, mock_uuid):
     """
     Tests that it does return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to True
+    and RETURN_HEADER is True
     """
     from django_guid.config import settings as guid_settings
 
     monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', True)
     response = client.get('/api')
     assert response.get('Access-Control-Expose-Headers')
+
+
+def test_no_expose_header_return_header_false(client, caplog, monkeypatch, mock_uuid):
+    """
+    Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to False
+    and RETURN_HEADER is False
+    """
+    from django_guid.config import settings as guid_settings
+
+    monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', False)
+    monkeypatch.setattr(guid_settings, 'RETURN_HEADER', False)
+    expected = [
+        ('No Correlation-ID found in the header. Added Correlation-ID: 704ae5472cae4f8daa8f2cc5a5a8mock', None),
+        ('This is a DRF view log, and should have a GUID.', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+        ('Some warning in a function', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+        ('Deleting 704ae5472cae4f8daa8f2cc5a5a8mock from _guid', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+    ]
+    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
+    response = client.get('/api')
+    assert not response.get('Access-Control-Expose-Headers')
+
+
+def test_expose_header_return_header_false(client, caplog, monkeypatch, mock_uuid):
+    """
+    Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to True
+    and RETURN_HEADER is False
+    """
+    from django_guid.config import settings as guid_settings
+
+    monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', True)
+    monkeypatch.setattr(guid_settings, 'RETURN_HEADER', False)
+    expected = [
+        ('No Correlation-ID found in the header. Added Correlation-ID: 704ae5472cae4f8daa8f2cc5a5a8mock', None),
+        ('This is a DRF view log, and should have a GUID.', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+        ('Some warning in a function', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+        ('Deleting 704ae5472cae4f8daa8f2cc5a5a8mock from _guid', '704ae5472cae4f8daa8f2cc5a5a8mock'),
+    ]
+    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
+
+    response = client.get('/api')
+    assert not response.get('Access-Control-Expose-Headers')
 
 
 #

--- a/tests/functional/test_middleware.py
+++ b/tests/functional/test_middleware.py
@@ -130,7 +130,7 @@ def test_expose_header_return_header_true(client, monkeypatch, mock_uuid):
     assert response.get('Access-Control-Expose-Headers')
 
 
-def test_no_expose_header_return_header_false(client, caplog, monkeypatch, mock_uuid):
+def test_no_expose_header_return_header_false(client, monkeypatch, mock_uuid):
     """
     Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to False
     and RETURN_HEADER is False
@@ -139,18 +139,11 @@ def test_no_expose_header_return_header_false(client, caplog, monkeypatch, mock_
 
     monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', False)
     monkeypatch.setattr(guid_settings, 'RETURN_HEADER', False)
-    expected = [
-        ('No Correlation-ID found in the header. Added Correlation-ID: 704ae5472cae4f8daa8f2cc5a5a8mock', None),
-        ('This is a DRF view log, and should have a GUID.', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-        ('Some warning in a function', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-        ('Deleting 704ae5472cae4f8daa8f2cc5a5a8mock from _guid', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-    ]
-    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
     response = client.get('/api')
     assert not response.get('Access-Control-Expose-Headers')
 
 
-def test_expose_header_return_header_false(client, caplog, monkeypatch, mock_uuid):
+def test_expose_header_return_header_false(client, monkeypatch, mock_uuid):
     """
     Tests that it does not return the Access-Control-Allow-Origin when EXPOSE_HEADER is set to True
     and RETURN_HEADER is False
@@ -159,14 +152,6 @@ def test_expose_header_return_header_false(client, caplog, monkeypatch, mock_uui
 
     monkeypatch.setattr(guid_settings, 'EXPOSE_HEADER', True)
     monkeypatch.setattr(guid_settings, 'RETURN_HEADER', False)
-    expected = [
-        ('No Correlation-ID found in the header. Added Correlation-ID: 704ae5472cae4f8daa8f2cc5a5a8mock', None),
-        ('This is a DRF view log, and should have a GUID.', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-        ('Some warning in a function', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-        ('Deleting 704ae5472cae4f8daa8f2cc5a5a8mock from _guid', '704ae5472cae4f8daa8f2cc5a5a8mock'),
-    ]
-    assert [(x.message, x.correlation_id) for x in caplog.records] == expected
-
     response = client.get('/api')
     assert not response.get('Access-Control-Expose-Headers')
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -35,6 +35,12 @@ def test_invalid_return_header_setting(monkeypatch):
         Settings()
 
 
+def test_invalid_expose_header_setting(monkeypatch):
+    monkeypatch.setattr(django_settings, 'DJANGO_GUID', {'EXPOSE_HEADER': 'string'})
+    with pytest.raises(ImproperlyConfigured, match='EXPOSE_HEADER must be a boolean'):
+        Settings()
+
+
 def test_valid_settings(monkeypatch):
     monkeypatch.setattr(
         django_settings,
@@ -44,6 +50,7 @@ def test_valid_settings(monkeypatch):
             'VALIDATE_GUID': False,
             'GUID_HEADER_NAME': 'Correlation-ID-TEST',
             'RETURN_HEADER': False,
+            'EXPOSE_HEADER': False,
         },
     )
     assert not Settings().VALIDATE_GUID


### PR DESCRIPTION
This PR adds a new option that is enabled by default named `EXPOSE_HEADER` that adds the `Access-Control-Expose-Headers` header for the GUID header if `RETURN_HEADER` is true. 

When using CORS, the JavaScript Fetch API is unable to access most headers, to allow access to headers that are not accessible by default, they have to be added to the `Access-Control-Expose-Headers` header. You can find more info on [this StackOverflow question](https://stackoverflow.com/questions/43344819/reading-response-headers-with-fetch-api)

Any feedback positive or negative is appreciated!