### PR TITLE
Fixed wrong setting documentation in the README. Version bump to fix PyPi docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+`1.1.1`_ - 2020-02-12
+---------------------
+
+**Improvements**
+
+* Fixed ``EXPOSE_HEADER`` documentation issue. New release has to be pushed to fix PyPi docs.
+
+
 `1.1.0`_ - 2020-02-10
 ---------------------
 
@@ -134,3 +142,4 @@ Changelog
 .. _1.0.0: https://github.com/jonasks/django-guid/compare/0.3.0...1.0.0
 .. _1.0.1: https://github.com/jonasks/django-guid/compare/1.0.0...1.0.1
 .. _1.1.0: https://github.com/jonasks/django-guid/compare/1.0.1...1.1.0
+.. _1.1.1: https://github.com/jonasks/django-guid/compare/1.1.0...1.1.1

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Settings
 
     Default: True
 
-* :code:`RETURN_HEADER`
+* :code:`EXPOSE_HEADER`
         Whether to return :code:`Access-Control-Expose-Headers` for the GUID header if
         :code:`RETURN_HEADER` is :code:`True`, has no effect if :code:`RETURN_HEADER` is :code:`False`.
         This is allows the JavaScript Fetch API to access the header when CORS is enabled.

--- a/django_guid/__init__.py
+++ b/django_guid/__init__.py
@@ -4,4 +4,4 @@ This file is imported by setup.py
 Adding imports here will break setup.py
 """
 
-__version__ = '1.1.0'
+__version__ = '1.1.1'


### PR DESCRIPTION
`RETURN_HEADER` was listed twice instead of `RETURN_HEADER` and `EXPOSE_HEADER`

Have to bump version in order to fix PyPi docs.