### PR TITLE
Docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,31 +21,33 @@ this makes debugging your application easy.
 
 Further integration is also possible, as the ID can be returned as a header, or you can include it as a header in outgoing requests, to extend the reach of IDs to whole systems.
 
-Log output with a GUID:
-
-.. code-block::
-
-    INFO 2020-01-14 15:40:48,955 [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.views This is a DRF view log, and should have a GUID.
-    INFO 2020-01-14 15:40:48,955 [99d44111e9174c5a9494275aa7f28858] project.views This is a DRF view log, and should have a GUID.
-    WARNING 2020-01-14 15:40:48,955 [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.services.file Some warning in a function
-    WARNING 2020-01-14 15:40:48,955 [99d44111e9174c5a9494275aa7f28858] project.services.file Some warning in a function
-    ...
-
-Log output without:
-
-.. code-block::
-
-    INFO 2020-01-14 15:40:48,955 project.views This is a DRF view log, and should have a GUID.
-    INFO 2020-01-14 15:40:48,955 project.views This is a DRF view log, and should have a GUID.
-    WARNING 2020-01-14 15:40:48,955 project.services.file Some warning in a function
-    WARNING 2020-01-14 15:40:48,955 project.services.file Some warning in a function
-    ...
-
-Resources:
+**Resources**:
 
 * Documentation: https://django-guid.readthedocs.io
 * Homepage: https://github.com/JonasKs/django-guid
 * Free software: BSD License
+
+**Examples**
+
+Log output with a GUID:
+
+.. code-block::
+
+    INFO ... [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.views This is a DRF view log, and should have a GUID.
+    INFO ... [99d44111e9174c5a9494275aa7f28858] project.views This is a DRF view log, and should have a GUID.
+    WARNING ... [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.services.file Some warning in a function
+    WARNING ... [99d44111e9174c5a9494275aa7f28858] project.services.file Some warning in a function
+
+Log output without a GUID:
+
+.. code-block::
+
+    INFO ... project.views This is a DRF view log, and should have a GUID.
+    INFO ... project.views This is a DRF view log, and should have a GUID.
+    WARNING ... project.services.file Some warning in a function
+    WARNING ... project.services.file Some warning in a function
+
+
 
 ************
 Installation

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,7 @@ Django GUID
 Django GUID attaches a unique correlation ID to all your log outputs for every requests you handle. This means that every error now has an ID connecting it to all other relevant logs, making
 debugging simple.
 
-Integration are also made possible, as the ID can be *returned as a header*,
-or can be added as an *outgoing header* in external requests, making it possible to extend the reach of correlation IDs to whole systems.
+Integration are also made possible, as the ID can be returned as a header, or added as an outgoing header in external requests, making it possible to extend the reach of correlation IDs to whole systems.
 
 **Resources**:
 

--- a/README.rst
+++ b/README.rst
@@ -23,9 +23,9 @@ Further integration is also possible, as the ID can be returned as a header, or 
 
 **Resources**:
 
+* Free software: BSD License
 * Documentation: https://django-guid.readthedocs.io
 * Homepage: https://github.com/JonasKs/django-guid
-* Free software: BSD License
 
 **Examples**
 
@@ -59,6 +59,8 @@ Installation
 ************
 
 Install using pip:
+
+.. code-block:: bash
 
     pip install django-guid
 

--- a/README.rst
+++ b/README.rst
@@ -16,10 +16,11 @@ Django GUID
     :target: https://django-guid.readthedocs.io/en/latest/?badge=latest
 
 
-Django GUID attaches a unique correlation ID to all your log outputs for every requests you handle. Since every error now has an ID tying connecting it to all other relevant logs,
-this makes debugging your application easy.
+Django GUID attaches a unique correlation ID to all your log outputs for every requests you handle. This means that every error now has an ID connecting it to all other relevant logs, making
+debugging simple.
 
-Further integration is also possible, as the ID can be returned as a header, or you can include it as a header in outgoing requests, to extend the reach of IDs to whole systems.
+Integration are also made possible, as the ID can be *returned as a header*,
+or can be added as an *outgoing header* in external requests, making it possible to extend the reach of correlation IDs to whole systems.
 
 **Resources**:
 
@@ -207,7 +208,7 @@ Simply add django_guid to your loggers in the project, like in the example below
         }
     }
 
-
+This is especially useful when implementing the package, if you plan to pass existing GUIDs to the middleware, as misconfigured GUIDs will not raise exceptions, but will generate warning logs.
 
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -33,21 +33,26 @@ Log output with a GUID:
 
 .. code-block::
 
+    INFO ... [773fa6885e03493498077a273d1b7f2d] project.views This is a DRF view log, and should have a GUID.
+    WARNING ... [773fa6885e03493498077a273d1b7f2d] project.services.file Some warning in a function
     INFO ... [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.views This is a DRF view log, and should have a GUID.
     INFO ... [99d44111e9174c5a9494275aa7f28858] project.views This is a DRF view log, and should have a GUID.
     WARNING ... [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.services.file Some warning in a function
     WARNING ... [99d44111e9174c5a9494275aa7f28858] project.services.file Some warning in a function
+
 
 Log output without a GUID:
 
 .. code-block::
 
     INFO ... project.views This is a DRF view log, and should have a GUID.
+    WARNING ... project.services.file Some warning in a function
+    INFO ... project.views This is a DRF view log, and should have a GUID.
     INFO ... project.views This is a DRF view log, and should have a GUID.
     WARNING ... project.services.file Some warning in a function
     WARNING ... project.services.file Some warning in a function
 
-
+See the `documentation <https://django-guid.readthedocs.io>`_ for more examples.
 
 ************
 Installation

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Install using pip:
 Settings
 ********
 
-Package settings are added in your :code:`settings.py`:
+Package settings are added in your ``settings.py``:
 
 .. code-block:: python
 
@@ -123,7 +123,7 @@ Package settings are added in your :code:`settings.py`:
 Configuration
 *************
 
-Once settings have been added, in your project's :code:`settings.py` you need to do the following:
+Once settings have set up, add the following to your projects' ``settings.py``:
 
 1. Middleware
 =============
@@ -140,8 +140,8 @@ Add the :code:`django_guid.middleware.GuidMiddleware` to your ``MIDDLEWARE``:
 
 It is recommended that you add the middleware at the top, so that the remaining middleware loggers include the requests GUID.
 
-2. Configuring Logging
-======================
+2. Logging Configuration
+========================
 
 Add :code:`django_guid.log_filters.CorrelationId` as a filter in your ``LOGGING`` configuration:
 
@@ -185,10 +185,10 @@ And make sure to add the new ``correlation_id`` filter to one or all of your for
     }
 
 
-If these settings were confusing, please have a look in the demo project's
+If these settings were confusing, please have a look in the demo projects'
 `settings.py <https://github.com/JonasKs/django-guid/blob/master/demoproj/settings.py>`_ file for a complete example.
 
-3. Adding the Django GUID logger
+3. Django GUID Logger (Optional)
 ================================
 
 If you wish to see the Django GUID middleware outputs, you may configure a logger for the module.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
+###########
 Django GUID
-===========
+###########
 
 .. image:: https://img.shields.io/pypi/v/django-guid.svg
     :target: https://pypi.python.org/pypi/django-guid
@@ -15,60 +16,65 @@ Django GUID
     :target: https://django-guid.readthedocs.io/en/latest/?badge=latest
 
 
-Django GUID stores a GUID to an object, making it accessible by using the ID of the current thread.
-The GUID is accessible from anywhere within the application throughout a request,
-allowing us to inject it into the logs.
+Django GUID attaches a unique correlation ID to all your log outputs for every requests you handle. Since every error now has an ID tying connecting it to all other relevant logs,
+this makes debugging your application easy.
 
-* Free software: BSD License
-* Homepage: https://github.com/JonasKs/django-guid
+Further integration is also possible, as the ID can be returned as a header, or you can include it as a header in outgoing requests, to extend the reach of IDs to whole systems.
+
+Log output with a GUID:
+
+.. code-block::
+
+    INFO 2020-01-14 15:40:48,955 [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.views This is a DRF view log, and should have a GUID.
+    INFO 2020-01-14 15:40:48,955 [99d44111e9174c5a9494275aa7f28858] project.views This is a DRF view log, and should have a GUID.
+    WARNING 2020-01-14 15:40:48,955 [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.services.file Some warning in a function
+    WARNING 2020-01-14 15:40:48,955 [99d44111e9174c5a9494275aa7f28858] project.services.file Some warning in a function
+    ...
+
+Log output without:
+
+.. code-block::
+
+    INFO 2020-01-14 15:40:48,955 project.views This is a DRF view log, and should have a GUID.
+    INFO 2020-01-14 15:40:48,955 project.views This is a DRF view log, and should have a GUID.
+    WARNING 2020-01-14 15:40:48,955 project.services.file Some warning in a function
+    WARNING 2020-01-14 15:40:48,955 project.services.file Some warning in a function
+    ...
+
+Resources:
+
 * Documentation: https://django-guid.readthedocs.io
+* Homepage: https://github.com/JonasKs/django-guid
+* Free software: BSD License
+
+************
+Installation
+************
+
+Install using pip:
+
+    pip install django-guid
 
 
-Example
--------
-
-Using ``demoproj`` as an example, all the log messages **without** ``django-guid`` would look like this:
-
-.. code-block:: bash
-
-    INFO 2020-01-14 12:28:42,194 django_guid.middleware No Correlation-ID found in the header. Added Correlation-ID: 97c304252fd14b25b72d6aee31565843
-    INFO 2020-01-14 12:28:42,353 demoproj.views This is a DRF view log, and should have a GUID.
-    INFO 2020-01-14 12:28:42,354 demoproj.services.useless_file Some warning in a function
-
-
-With ``django-guid`` every log message has a GUID attached to it(``97c304252fd14b25b72d6aee31565843``),
-through the entire stack:
-
-.. code-block:: bash
-
-    INFO 2020-01-14 12:28:42,194 [None] django_guid.middleware No Correlation-ID found in the header. Added Correlation-ID: 97c304252fd14b25b72d6aee31565843
-    INFO 2020-01-14 12:28:42,353 [97c304252fd14b25b72d6aee31565843] demoproj.views This is a DRF view log, and should have a GUID.
-    INFO 2020-01-14 12:28:42,354 [97c304252fd14b25b72d6aee31565843] demoproj.services.useless_file Some warning in a function
-
-For multiple requests at the same time over multiple threads, see the `extended example docs <https://django-guid.readthedocs.io/en/latest/extended_example.html>`_.
-
-
-Why
----
-
-``django-guid`` makes it extremely easy to track exactly what happened in any request. If you see an error
-in your log, you can use the attached GUID to search for any connected log message to that single request.
-The GUID can also be returned as a header and displayed to the end user of your application, allowing them
-to report an issue with a connected ID. ``django-guid`` makes troubleshooting easy.
-
-
+********
 Settings
---------
+********
 
-* :code:`SKIP_CLEANUP`
-        After the request is done, the GUID is deleted to avoid memory leaks. Memory leaks can happen in the
-        case of many threads, or especially when using Gunicorn :code:`max_requests` or similar settings,
-        where the number of thread IDs can potentially scale for ever.
-        Having clean up enabled ensures we can not have memory leaks, but comes at the cost that anything that happens
-        after this middleware will not have the GUID attached, such as :code:`django.request` or :code:`django.server`
-        logs. If you do not want clean up of GUIDs and know what you're doing, you can enable :code:`SKIP_CLEANUP`.
+Package settings are added in your :code:`settings.py`.
 
-    Default: False
+Example:
+
+.. code-block:: python
+
+    DJANGO_GUID = {
+        GUID_HEADER_NAME = 'Correlation-ID',
+        VALIDATE_GUID = True,
+        RETURN_HEADER = True,
+        EXPOSE_HEADER = True,
+        SKIP_CLEANUP = False,
+    }
+
+Details:
 
 * :code:`GUID_HEADER_NAME`
         The name of the GUID to look for in a header in an incoming request. Remember that it's case insensitive.
@@ -94,18 +100,26 @@ Settings
 
     Default: True
 
+* :code:`SKIP_CLEANUP`
+        After the request is done, the GUID is deleted to avoid memory leaks. Memory leaks can happen in the
+        case of many threads, or especially when using Gunicorn :code:`max_requests` or similar settings,
+        where the number of thread IDs can potentially scale for ever.
+        Having clean up enabled ensures we can not have memory leaks, but comes at the cost that anything that happens
+        after this middleware will not have the GUID attached, such as :code:`django.request` or :code:`django.server`
+        logs. If you do not want clean up of GUIDs and know what you're doing, you can enable :code:`SKIP_CLEANUP`.
 
-Installation
-------------
+    Default: False
 
-Install using pip:
+*************
+Configuration
+*************
 
-    pip install django-guid
+Once settings have been added, in your project's :code:`settings.py` you need to do the following:
 
+1. Middleware
+=============
 
-Then, in your project's :code:`settings.py` add these settings:
-
-Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
+Add the :code:`django_guid.middleware.GuidMiddleware` to your ``MIDDLEWARE``:
 
 .. code-block:: python
 
@@ -115,7 +129,12 @@ Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlatio
      ]
 
 
-Add a filter to your ``LOGGING``:
+It is recommended that you add the middleware at the top, so that the remaining middleware loggers include the requests GUID.
+
+2. Configuring Logging
+======================
+
+Add :code:`django_guid.log_filters.CorrelationId` as a filter in your ``LOGGING`` configuration:
 
 .. code-block:: python
 
@@ -127,7 +146,6 @@ Add a filter to your ``LOGGING``:
             }
         }
     }
-
 
 Put that filter in your handler:
 
@@ -144,7 +162,7 @@ Put that filter in your handler:
         }
     }
 
-Lastly make sure we add the new ``correlation_id`` filter to the formatters:
+And make sure to add the new ``correlation_id`` filter to one or all of your formatters:
 
 .. code-block:: python
 
@@ -157,12 +175,15 @@ Lastly make sure we add the new ``correlation_id`` filter to the formatters:
         }
     }
 
+
 If these settings were confusing, please have a look in the demo project's
 `settings.py <https://github.com/JonasKs/django-guid/blob/master/demoproj/settings.py>`_ file for a complete example.
 
+3. Adding the Django GUID logger
+================================
 
-
-If you wish to aggregate the django-guid logs to your console or other handlers, add django_guid to your loggers in the project. Example:
+If you wish to see the Django GUID middleware outputs, you may configure a logger for the module.
+Simply add django_guid to your loggers in the project, like in the example below:
 
 .. code-block:: python
 
@@ -178,7 +199,8 @@ If you wish to aggregate the django-guid logs to your console or other handlers,
     }
 
 
+
 ----------
 
-Inspired by `django-log-request-id <https://github.com/dabapps/django-log-request-id>`_ with a complete rewritten
+This package was inspired by `django-log-request-id <https://github.com/dabapps/django-log-request-id>`_ with a complete rewritten
 `django-echelon <https://github.com/seveas/django-echelon>`_ approach.

--- a/README.rst
+++ b/README.rst
@@ -69,9 +69,7 @@ Install using pip:
 Settings
 ********
 
-Package settings are added in your :code:`settings.py`.
-
-Example:
+Package settings are added in your :code:`settings.py`:
 
 .. code-block:: python
 
@@ -83,7 +81,6 @@ Example:
         SKIP_CLEANUP = False,
     }
 
-Details:
 
 * :code:`GUID_HEADER_NAME`
         The name of the GUID to look for in a header in an incoming request. Remember that it's case insensitive.

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Django GUID
 Django GUID attaches a unique correlation ID to all your log outputs for every requests you handle. This means that every error now has an ID connecting it to all other relevant logs, making
 debugging simple.
 
-Integration are also made possible, as the ID can be returned as a header, or added as an outgoing header in external requests, making it possible to extend the reach of correlation IDs to whole systems.
+Integration are also made possible, as the ID can be returned as a header, or forwarded, making it possible to extend the reach of correlation IDs to whole systems.
 
 **Resources**:
 

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,9 @@ Package settings are added in your :code:`settings.py`:
     }
 
 
+
+**Optional Parameters**
+
 * :code:`GUID_HEADER_NAME`
         The name of the GUID to look for in a header in an incoming request. Remember that it's case insensitive.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,6 @@
+###########
 Django GUID
-===========
+###########
 
 .. image:: https://img.shields.io/pypi/v/django-guid.svg
     :target: https://pypi.python.org/pypi/django-guid
@@ -14,57 +15,40 @@ Django GUID
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://django-guid.readthedocs.io/en/latest/?badge=latest
 
-Django GUID stores a GUID to an object, making it accessible by using the ID of the current thread.
-The GUID is accessible from anywhere within the application throughout a request,
-allowing us to inject it into the logs.
+
+Django GUID attaches a unique correlation ID to all your log outputs for every requests you handle. This means that every error now has an ID connecting it to all other relevant logs, making
+debugging simple.
+
+Integration are also made possible, as the ID can be *returned as a header*,
+or can be added as an *outgoing header* in external requests, making it possible to extend the reach of correlation IDs to whole systems.
+
+**Resources**:
 
 * Free software: BSD License
-* Homepage: https://github.com/JonasKs/django-guid
 * Documentation: https://django-guid.readthedocs.io
+* Homepage: https://github.com/JonasKs/django-guid
+
+**Examples**
+
+Log output with a GUID:
+
+.. code-block::
+
+    INFO ... [773fa6885e03493498077a273d1b7f2d] project.views This is a DRF view log, and should have a GUID.
+    WARNING ... [773fa6885e03493498077a273d1b7f2d] project.services.file Some warning in a function
+    INFO ... [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.views This is a DRF view log, and should have a GUID.
+    INFO ... [99d44111e9174c5a9494275aa7f28858] project.views This is a DRF view log, and should have a GUID.
+    WARNING ... [0d1c3919e46e4cd2b2f4ac9a187a8ea1] project.services.file Some warning in a function
+    WARNING ... [99d44111e9174c5a9494275aa7f28858] project.services.file Some warning in a function
 
 
-Example
--------
+Log output without a GUID:
 
-Using ``demoproj`` as an example, all the log messages **without** ``django-guid`` would look like this:
+.. code-block::
 
-.. code-block:: bash
-
-    INFO 2020-01-14 12:28:42,194 django_guid.middleware No Correlation-ID found in the header. Added Correlation-ID: 97c304252fd14b25b72d6aee31565843
-    INFO 2020-01-14 12:28:42,353 demoproj.views This is a DRF view log, and should have a GUID.
-    INFO 2020-01-14 12:28:42,354 demoproj.services.useless_file Some warning in a function
-
-With ``django-guid`` every log message has a GUID (``97c304252fd14b25b72d6aee31565843``) attached to it,
-through the entire stack:
-
-.. code-block:: bash
-
-    INFO 2020-01-14 12:28:42,194 [None] django_guid.middleware No Correlation-ID found in the header. Added Correlation-ID: 97c304252fd14b25b72d6aee31565843
-    INFO 2020-01-14 12:28:42,353 [97c304252fd14b25b72d6aee31565843] demoproj.views This is a DRF view log, and should have a GUID.
-    INFO 2020-01-14 12:28:42,354 [97c304252fd14b25b72d6aee31565843] demoproj.services.useless_file Some warning in a function
-
-For multiple requests at the same time over multiple threads, see the :ref:`extended_example`.
-
-Why
----
-
-``django-guid`` makes it extremely easy to track exactly what happened in any request. If you see one error
-in your log, you can use the attached GUID to search for any connected log message to that single request.
-The GUID can also be returned as a header and displayed to the end user of your application, allowing them
-to report an issue with a connected ID. ``django-guid`` makes troubleshooting easy.
-
-
-Contents
---------
-
-.. toctree::
-    :maxdepth: 3
-
-    install
-    settings
-    api
-    extended_example
-    troubleshooting
-    contributing
-    publish
-    changelog
+    INFO ... project.views This is a DRF view log, and should have a GUID.
+    WARNING ... project.services.file Some warning in a function
+    INFO ... project.views This is a DRF view log, and should have a GUID.
+    INFO ... project.views This is a DRF view log, and should have a GUID.
+    WARNING ... project.services.file Some warning in a function
+    WARNING ... project.services.file Some warning in a function

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,19 +8,20 @@ Django GUID
     :target: https://pypi.python.org/pypi/django-guid#downloads
 .. image:: https://img.shields.io/pypi/djversions/django-guid.svg
     :target: https://pypi.python.org/pypi/django-guid
-.. image:: https://codecov.io/gh/jonasks/django-guid/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/jonasks/django-guid
 .. image:: https://readthedocs.org/projects/django-guid/badge/?version=latest
     :target: https://django-guid.readthedocs.io/en/latest/?badge=latest
+.. image:: https://codecov.io/gh/jonasks/django-guid/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/jonasks/django-guid
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://django-guid.readthedocs.io/en/latest/?badge=latest
+.. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
+    :target: https://github.com/pre-commit/pre-commit
 
 
-Django GUID attaches a unique correlation ID to all your log outputs for every requests you handle. This means that every error now has an ID connecting it to all other relevant logs, making
+Django GUID attaches a unique correlation ID to all your log outputs for every requests you handle. In other words, every error, and really every log now has an ID connecting it to all other relevant logs, making
 debugging simple.
 
-Integration are also made possible, as the ID can be *returned as a header*,
-or can be added as an *outgoing header* in external requests, making it possible to extend the reach of correlation IDs to whole systems.
+The package stores a GUID to an object, making it accessible by using the ID of the current thread. This makes integrations possible, as the ID can be returned as a header (built in setting) or forwarded manually to other systems (built in API), making it possible to extend the reach of correlation IDs to whole systems.
 
 **Resources**:
 
@@ -32,7 +33,7 @@ or can be added as an *outgoing header* in external requests, making it possible
 
 Log output with a GUID:
 
-.. code-block::
+.. code-block:: none
 
     INFO ... [773fa6885e03493498077a273d1b7f2d] project.views This is a DRF view log, and should have a GUID.
     WARNING ... [773fa6885e03493498077a273d1b7f2d] project.services.file Some warning in a function
@@ -44,7 +45,7 @@ Log output with a GUID:
 
 Log output without a GUID:
 
-.. code-block::
+.. code-block:: none
 
     INFO ... project.views This is a DRF view log, and should have a GUID.
     WARNING ... project.services.file Some warning in a function

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,3 +52,18 @@ Log output without a GUID:
     INFO ... project.views This is a DRF view log, and should have a GUID.
     WARNING ... project.services.file Some warning in a function
     WARNING ... project.services.file Some warning in a function
+
+Contents
+--------
+
+.. toctree::
+    :maxdepth: 3
+
+    install
+    settings
+    api
+    extended_example
+    troubleshooting
+    contributing
+    publish
+    changelog

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,14 +9,14 @@ Install using pip:
     pip install django-guid
 
 
-*************
+
 Configuration
-*************
+=============
 
 Once settings have set up, add the following to your projects' ``settings.py``:
 
 1. Middleware
-=============
+-------------
 
 Add the :code:`django_guid.middleware.GuidMiddleware` to your ``MIDDLEWARE``:
 
@@ -31,7 +31,7 @@ Add the :code:`django_guid.middleware.GuidMiddleware` to your ``MIDDLEWARE``:
 It is recommended that you add the middleware at the top, so that the remaining middleware loggers include the requests GUID.
 
 2. Logging Configuration
-========================
+------------------------
 
 Add :code:`django_guid.log_filters.CorrelationId` as a filter in your ``LOGGING`` configuration:
 
@@ -79,7 +79,7 @@ If these settings were confusing, please have a look in the demo projects'
 `settings.py <https://github.com/JonasKs/django-guid/blob/master/demoproj/settings.py>`_ file for a complete example.
 
 3. Django GUID Logger (Optional)
-================================
+--------------------------------
 
 If you wish to see the Django GUID middleware outputs, you may configure a logger for the module.
 Simply add django_guid to your loggers in the project, like in the example below:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,23 +1,24 @@
+************
 Installation
-============
-
-Requirements
-------------
-
-* Python 3.6 and above (May work on older versions too)
-* Django 2.2 and above (Header setting used in the middleware was added in Django 2.2)
-
-Package installation
---------------------
+************
 
 Install using pip:
+
+.. code-block:: bash
 
     pip install django-guid
 
 
-Then, in your project's :code:`settings.py` add these settings:
+*************
+Configuration
+*************
 
-Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlation-ID to span your middleware-logs, put it on top):
+Once settings have set up, add the following to your projects' ``settings.py``:
+
+1. Middleware
+=============
+
+Add the :code:`django_guid.middleware.GuidMiddleware` to your ``MIDDLEWARE``:
 
 .. code-block:: python
 
@@ -27,7 +28,12 @@ Add the middleware to the :code:`MIDDLEWARE` setting (if you want the correlatio
      ]
 
 
-Add a filter to your ``LOGGING``:
+It is recommended that you add the middleware at the top, so that the remaining middleware loggers include the requests GUID.
+
+2. Logging Configuration
+========================
+
+Add :code:`django_guid.log_filters.CorrelationId` as a filter in your ``LOGGING`` configuration:
 
 .. code-block:: python
 
@@ -39,7 +45,6 @@ Add a filter to your ``LOGGING``:
             }
         }
     }
-
 
 Put that filter in your handler:
 
@@ -56,7 +61,7 @@ Put that filter in your handler:
         }
     }
 
-Lastly make sure we add the new ``correlation_id`` filter to the formatters:
+And make sure to add the new ``correlation_id`` filter to one or all of your formatters:
 
 .. code-block:: python
 
@@ -69,12 +74,15 @@ Lastly make sure we add the new ``correlation_id`` filter to the formatters:
         }
     }
 
-If these settings were confusing, please have a look in the demo project's
+
+If these settings were confusing, please have a look in the demo projects'
 `settings.py <https://github.com/JonasKs/django-guid/blob/master/demoproj/settings.py>`_ file for a complete example.
 
+3. Django GUID Logger (Optional)
+================================
 
-
-If you wish to aggregate the django-guid logs to your console or other handlers, add django_guid to your loggers in the project. Example:
+If you wish to see the Django GUID middleware outputs, you may configure a logger for the module.
+Simply add django_guid to your loggers in the project, like in the example below:
 
 .. code-block:: python
 
@@ -88,3 +96,5 @@ If you wish to aggregate the django-guid logs to your console or other handlers,
             }
         }
     }
+
+This is especially useful when implementing the package, if you plan to pass existing GUIDs to the middleware, as misconfigured GUIDs will not raise exceptions, but will generate warning logs.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,6 +1,22 @@
 Settings
 ========
 
+Package settings are added in your ``settings.py``:
+
+Default settings are shown below:
+
+.. code-block:: python
+
+    DJANGO_GUID = {
+        GUID_HEADER_NAME = 'Correlation-ID',
+        VALIDATE_GUID = True,
+        RETURN_HEADER = True,
+        EXPOSE_HEADER = True,
+        SKIP_CLEANUP = False,
+    }
+
+
+
 .. _skip_cleanup_setting:
 
 SKIP_CLEANUP

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -17,19 +17,6 @@ Default settings are shown below:
 
 
 
-.. _skip_cleanup_setting:
-
-SKIP_CLEANUP
-------------
-* **Default**: ``False``
-* **Type**: ``boolean``
-
-After the request is done, the GUID is deleted to avoid memory leaks. Memory leaks can happen in the
-case of many threads, or especially when using Gunicorn :code:`max_requests` or similar settings,
-where the number of thread IDs can potentially scale for ever.
-Having clean up enabled ensures we can not have memory leaks, but comes at the cost that anything that happens
-after this middleware will not have the GUID attached, such as :code:`django.request` or :code:`django.server`
-logs. If you do not want clean up of GUIDs and know what you're doing, you can enable :code:`SKIP_CLEANUP`.
 
 
 .. _guid_header_name_setting:
@@ -70,3 +57,17 @@ EXPOSE_HEADER
 Whether to return :code:`Access-Control-Expose-Headers` for the GUID header if
 :code:`RETURN_HEADER` is :code:`True`, has no effect if :code:`RETURN_HEADER` is :code:`False`.
 This is allows the JavaScript Fetch API to access the header when CORS is enabled.
+
+.. _skip_cleanup_setting:
+
+SKIP_CLEANUP
+------------
+* **Default**: ``False``
+* **Type**: ``boolean``
+
+After the request is done, the GUID is deleted to avoid memory leaks. Memory leaks can happen in the
+case of many threads, or especially when using Gunicorn :code:`max_requests` or similar settings,
+where the number of thread IDs can potentially scale for ever.
+Having clean up enabled ensures we can not have memory leaks, but comes at the cost that anything that happens
+after this middleware will not have the GUID attached, such as :code:`django.request` or :code:`django.server`
+logs. If you do not want clean up of GUIDs and know what you're doing, you can enable :code:`SKIP_CLEANUP`.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -10,7 +10,7 @@ Set the logger to log DEBUG logs from django-guid:
 
     LOGGING = {
         'loggers': {
-            'django-guid': {
+            'django_guid': {
                 'handlers': ['console'],
                 'level': 'DEBUG',
             },


### PR DESCRIPTION
Suggestion for how the readme might be restructured. I've implemented the package in three separate project over the last weeks, and there's just a few things that I've missed/noticed:

- An example `DJANGO_GUID` object for settings.py
- A clear separation between the middleware setup and the logging configuration
- The first few lines a new user reads don't fully encapsulate what the package *does*, but rather, how the solution is implemented (not saying this suggestion is better, but could work as a first draft if you have any thoughts)

